### PR TITLE
Pip 844 baseimage sha

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,3 +331,4 @@ workflows:
             - test_workflow_docker
             - test_workflow_singularity
             - test_workflow_2reps_docker
+            - test_workflow_2reps_singularity

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Dockerfile for ENCODE-DCC mirna-seq-pipeline
-FROM ubuntu:16.04
+# base on ubuntu 16.04
+FROM ubuntu@sha256:e10375c69cf9e22989c82b0a87c932a21e33619ee322d6c7ce6a61456f54c30c
 MAINTAINER Otto Jolanki
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
For safety and consistency, use sha instead of tag.